### PR TITLE
Fix validation of the CME Provider.

### DIFF
--- a/CME/admin/components/FrontMatter/Edit.php
+++ b/CME/admin/components/FrontMatter/Edit.php
@@ -167,7 +167,7 @@ HTML;
 	// }}}
 	// {{{ protected function validateProvider()
 
-	protected function validateProvider(CMEProvider $provider)
+	protected function validateProvider(CMEProvider $provider = null)
 	{
 		return true;
 	}


### PR DESCRIPTION
If no CME provider is chosen, then the variable is nul.
