### PR TITLE
Set a default passing percentage on new FrontMatters.

### DIFF
--- a/CME/admin/components/FrontMatter/Edit.php
+++ b/CME/admin/components/FrontMatter/Edit.php
@@ -133,10 +133,30 @@ abstract class CMEFrontMatterEdit extends AdminObjectEdit
 	protected function setDefaultValues()
 	{
 		$this->ui->getWidget('enabled')->value = true;
-		$this->ui->getWidget('objectives')->value = <<<HTML
+		$this->ui->getWidget('passing_grade')->value =
+			$this->getDefaultPassingGrade();
+
+		$this->ui->getWidget('objectives')->value =
+			$this->getDefaultObjectives();
+	}
+
+	// }}}
+	// {{{ protected function getDefaultPassingGrade()
+
+	protected function getDefaultPassingGrade()
+	{
+		return 0.70;
+	}
+
+	// }}}
+	// {{{ protected function getDefaultObjectives()
+
+	protected function getDefaultObjectives()
+	{
+		return <<<HTML
 <ul>
-<li>objective1</li>
-<li>objective2</li>
+	<li>objective1</li>
+	<li>objective2</li>
 </ul>
 HTML;
 	}


### PR DESCRIPTION
All current quizzes have a pass percentage of 70%, so this should be safe, and is easily subclassable.

Bonus restructure to make the default objectives easier to subclass as well.