### PR TITLE
Better notifications for quiz/eval completion

### DIFF
--- a/CME/pages/CMEEvaluationPage.php
+++ b/CME/pages/CMEEvaluationPage.php
@@ -725,6 +725,11 @@ abstract class CMEEvaluationPage extends SiteDBEditPage
 	}
 
 	// }}}
+	// {{{ abstract protected function getCompletionEmailClass()
+
+	abstract protected function getCompletionEmailClass();
+
+	// }}}
 	// {{{ abstract protected function relocateForCompletedEvaluation()
 
 	abstract protected function relocateForCompletedEvaluation();

--- a/CME/pages/CMEEvaluationPage.php
+++ b/CME/pages/CMEEvaluationPage.php
@@ -6,6 +6,7 @@ require_once 'Site/pages/SiteDBEditPage.php';
 require_once 'Inquisition/dataobjects/InquisitionQuestionWrapper.php';
 require_once 'Inquisition/dataobjects/InquisitionQuestionOptionWrapper.php';
 require_once 'CME/CME.php';
+require_once 'CME/CMEFrontMatterCompleteMailMessage.php';
 require_once 'CME/dataobjects/CMEEvaluationWrapper.php';
 require_once 'CME/dataobjects/CMECreditWrapper.php';
 require_once 'CME/dataobjects/CMEFrontMatterWrapper.php';
@@ -617,6 +618,7 @@ abstract class CMEEvaluationPage extends SiteDBEditPage
 		// save responses
 		$this->inquisition_response->save();
 		$this->saveEarnedCredits();
+		$this->sendCompletionEmail();
 
 		// clear CME hours cache for this account
 		$key = 'cme-hours-'.$this->app->session->account->id;
@@ -694,6 +696,32 @@ abstract class CMEEvaluationPage extends SiteDBEditPage
 	protected function getMessageSecondaryContent(SwatForm $form)
 	{
 		return null;
+	}
+
+	// }}}
+	// {{{ protected function sendCompletionEmail()
+
+	protected function sendCompletionEmail()
+	{
+		// only send email if quiz is complete
+		$account = $this->app->session->account;
+		if (!$this->credits->getFirst()->isEarned($account) ||
+			!$this->progress->quiz instanceof CMEQuiz) {
+			return;
+		}
+
+		try {
+			$class_name = $this->getCompletionEmailClass();
+			$message = new $class_name(
+				$this->app,
+				$account,
+				$this->front_matter,
+				$this->progress->quiz->getResponseByAccount($account)
+			);
+			$message->send();
+		} catch (SiteMailException $e) {
+			$e->processAndContinue();
+		}
 	}
 
 	// }}}

--- a/CME/pages/CMEQuizPage.php
+++ b/CME/pages/CMEQuizPage.php
@@ -118,15 +118,14 @@ abstract class CMEQuizPage extends SiteDBEditPage
 		$this->initFrontMatter();
 		$this->initProgress();
 		$this->initQuiz();
+		$this->initResponse();
 
 		// if there is no quiz, go to evaluation page
 		if (!$this->quiz instanceof CMEQuiz) {
-			if (!$response->complete_date instanceof SwatDate) {
+			if (!$this->response->complete_date instanceof SwatDate) {
 				$this->relocateToEvaluation();
 			}
 		}
-
-		$this->initResponse();
 
 		if ($this->isComplete()) {
 			// If earned credit was accidentally deleted but quiz is already
@@ -530,6 +529,7 @@ abstract class CMEQuizPage extends SiteDBEditPage
 		$this->response->values->save();
 		$this->saveEarnedCredit();
 		$this->sendCompletionEmail();
+		$this->addCompletionMessage();
 
 		// clear CME hours cache for this account
 		$key = 'cme-hours-'.$this->app->session->account->id;
@@ -606,17 +606,48 @@ abstract class CMEQuizPage extends SiteDBEditPage
 
 	protected function sendCompletionEmail()
 	{
+		// only send email if credits are earned
+		$account = $this->app->session->account;
+		if (!$this->credits->getFirst()->isEarned($account)) {
+			return;
+		}
+
 		try {
 			$class_name = $this->getCompletionEmailClass();
 			$message = new $class_name(
 				$this->app,
-				$this->app->session->account,
+				$account,
 				$this->front_matter,
 				$this->response
 			);
 			$message->send();
 		} catch (SiteMailException $e) {
 			$e->processAndContinue();
+		}
+	}
+
+	// }}}
+	// {{{ protected function addCompletionMessage()
+
+	protected function addCompletionMessage()
+	{
+		if ($this->response->isPassed()) {
+			$message = new SwatMessage(
+				sprintf(
+					CME::_('Congratulations on passing the %s quiz!'),
+					$this->getQuizTitle()
+				)
+			);
+
+			$account = $this->app->session->account;
+			if (!$account->isEvaluationComplete($this->credits->getFirst())) {
+				$message->secondary_content = CME::_(
+					'Take a moment to complete this evaluation, and then '.
+					'you’ll be able to print your certificate.'
+				);
+			}
+
+			$this->app->messages->add($message);
 		}
 	}
 
@@ -640,6 +671,11 @@ abstract class CMEQuizPage extends SiteDBEditPage
 	// {{{ abstract protected function getCompletionEmailClass()
 
 	abstract protected function getCompletionEmailClass();
+
+	// }}}
+	// {{{ abstract protected function getQuizTitle()
+
+	abstract protected function getQuizTitle();
 
 	// }}}
 

--- a/CME/pages/CMEQuizPage.php
+++ b/CME/pages/CMEQuizPage.php
@@ -634,7 +634,7 @@ abstract class CMEQuizPage extends SiteDBEditPage
 		if ($this->response->isPassed()) {
 			$message = new SwatMessage(
 				sprintf(
-					CME::_('Congratulations on passing the %s quiz!'),
+					CME::_('Congratulations on passing the %s quiz'),
 					$this->getQuizTitle()
 				)
 			);

--- a/CME/pages/CMEQuizPage.php
+++ b/CME/pages/CMEQuizPage.php
@@ -640,7 +640,8 @@ abstract class CMEQuizPage extends SiteDBEditPage
 			);
 
 			$account = $this->app->session->account;
-			if (!$account->isEvaluationComplete($this->credits->getFirst())) {
+			if ($this->front_matter->evaluation instanceof CMEEvaluation &&
+				!$account->isEvaluationComplete($this->credits->getFirst())) {
 				$message->secondary_content = CME::_(
 					'Take a moment to complete this evaluation, and then '.
 					'you’ll be able to print your certificate.'


### PR DESCRIPTION
1) if eval is completed first, just proceed to quiz. When quiz is complete, send email.
2) if eval is completed second, show message on eval page that quiz was passed, and then send email when eval is complete