### PR TITLE
Cache progress and responses.

### DIFF
--- a/CME/dataobjects/CMEAccount.php
+++ b/CME/dataobjects/CMEAccount.php
@@ -313,7 +313,7 @@ abstract class CMEAccount extends StoreAccount
 	// }}}
 	// {{{ public function getResponseByCMEQuiz()
 
-	public function getResponseByCMEQuiz($quiz)
+	public function getResponseByCMEQuiz($quiz_id)
 	{
 		require_once 'CME/dataobjects/CMEQuizResponseWrapper.php';
 
@@ -341,15 +341,15 @@ abstract class CMEAccount extends StoreAccount
 			}
 		}
 
-		return (isset($this->response_by_cme_quiz[$quiz]))
-			? $this->response_by_cme_quiz[$quiz]
+		return (isset($this->response_by_cme_quiz[$quiz_id]))
+			? $this->response_by_cme_quiz[$quiz_id]
 			: null;
 	}
 
 	// }}}
 	// {{{ public function getResponseByCMEEvaluation()
 
-	public function getResponseByCMEEvaluation($evaluation)
+	public function getResponseByCMEEvaluation($evaluation_id)
 	{
 		require_once 'CME/dataobjects/CMEEvaluationResponseWrapper.php';
 
@@ -359,8 +359,7 @@ abstract class CMEAccount extends StoreAccount
 			$this->response_by_cme_eval[] = array();
 
 			$sql = sprintf(
-				'select * from InquisitionResponse
-				where account = %s and reset_date is null',
+				'select * from InquisitionResponse where account = %s',
 				$this->db->quote($this->id, 'integer')
 			);
 
@@ -377,8 +376,8 @@ abstract class CMEAccount extends StoreAccount
 			}
 		}
 
-		return (isset($this->response_by_cme_eval[$evaluation]))
-			? $this->response_by_cme_eval[$evaluation]
+		return (isset($this->response_by_cme_eval[$evaluation_id]))
+			? $this->response_by_cme_eval[$evaluation_id]
 			: null;
 	}
 

--- a/CME/dataobjects/CMEAccount.php
+++ b/CME/dataobjects/CMEAccount.php
@@ -67,7 +67,7 @@ abstract class CMEAccount extends StoreAccount
 		$progress = $this->getCMEProgress($credit);
 
 		if ($progress instanceof CMEAccountCMEProgress &&
-			$progress->hasInternalValue('evaluation')) {;
+			$progress->hasInternalValue('evaluation')) {
 
 			$response = $this->getResponseByCMEEvaluation(
 				$progress->getInternalValue('evaluation')
@@ -92,7 +92,7 @@ abstract class CMEAccount extends StoreAccount
 		$progress = $this->getCMEProgress($credit);
 
 		if ($progress instanceof CMEAccountCMEProgress &&
-			$progress->hasInternalValue('quiz')) {;
+			$progress->hasInternalValue('quiz')) {
 
 			$quiz_response = $this->getResponseByCMEQuiz(
 				$progress->getInternalValue('quiz')
@@ -118,7 +118,7 @@ abstract class CMEAccount extends StoreAccount
 			$progress = $this->getCMEProgress($credit);
 
 			if ($progress instanceof CMEAccountCMEProgress &&
-				$progress->hasInternalValue('quiz')) {;
+				$progress->hasInternalValue('quiz')) {
 
 				$quiz_response = $this->getResponseByCMEQuiz(
 					$progress->getInternalValue('quiz')

--- a/CME/dataobjects/CMEAccount.php
+++ b/CME/dataobjects/CMEAccount.php
@@ -328,8 +328,11 @@ abstract class CMEAccount extends StoreAccount
 				$this->db->quote($this->id, 'integer')
 			);
 
-			$responses = SwatDB::query($this->db, $sql,
-				SwatDBClassMap::get('CMEQuizResponseWrapper'));
+			$responses = SwatDB::query(
+				$this->db,
+				$sql,
+				SwatDBClassMap::get('CMEQuizResponseWrapper')
+			);
 
 			foreach ($responses as $response) {
 				$id = $response->getInternalValue('inquisition');
@@ -361,8 +364,11 @@ abstract class CMEAccount extends StoreAccount
 				$this->db->quote($this->id, 'integer')
 			);
 
-			$responses = SwatDB::query($this->db, $sql,
-				SwatDBClassMap::get('CMEEvaluationResponseWrapper'));
+			$responses = SwatDB::query(
+				$this->db,
+				$sql,
+				SwatDBClassMap::get('CMEEvaluationResponseWrapper')
+			);
 
 			foreach ($responses as $response) {
 				$id = $response->getInternalValue('inquisition');

--- a/CME/dataobjects/CMEQuizResponse.php
+++ b/CME/dataobjects/CMEQuizResponse.php
@@ -44,13 +44,7 @@ class CMEQuizResponse extends InquisitionResponse
 
 	public function getGrade()
 	{
-		$question_count = count($this->inquisition->question_bindings);
-
-		if ($question_count === 0) {
-			return 0;
-		}
-
-		return $this->getCorrectCount() / $question_count;
+		return $this->grade;
 	}
 
 	// }}}
@@ -60,7 +54,7 @@ class CMEQuizResponse extends InquisitionResponse
 	{
 		return (
 			$this->getGrade() >=
-			$this->getCredits()->getFirst()->front_matter->passing_grade
+			$this->credits->getFirst()->front_matter->passing_grade
 		);
 	}
 
@@ -68,6 +62,27 @@ class CMEQuizResponse extends InquisitionResponse
 	// {{{ public function getCredits()
 
 	public function getCredits()
+	{
+		return $this->credits;
+	}
+
+	// }}}
+	// {{{ protected function init()
+
+	protected function init()
+	{
+		parent::init();
+		$this->registerDateProperty('reset_date');
+		$this->registerInternalProperty(
+			'account',
+			SwatDBClassMap::get('CMEAccount')
+		);
+	}
+
+	// }}}
+	// {{{ public function loadCredits()
+
+	public function loadCredits()
 	{
 		require_once 'CME/dataobjects/CMECreditWrapper.php';
 
@@ -90,19 +105,6 @@ class CMEQuizResponse extends InquisitionResponse
 			$this->db,
 			$sql,
 			SwatDBClassMap::get('CMECreditWrapper')
-		);
-	}
-
-	// }}}
-	// {{{ protected function init()
-
-	protected function init()
-	{
-		parent::init();
-		$this->registerDateProperty('reset_date');
-		$this->registerInternalProperty(
-			'account',
-			SwatDBClassMap::get('CMEAccount')
 		);
 	}
 

--- a/CME/dataobjects/CMEQuizResponse.php
+++ b/CME/dataobjects/CMEQuizResponse.php
@@ -89,6 +89,7 @@ class CMEQuizResponse extends InquisitionResponse
 		$this->checkDB();
 
 		$inquisition_id = $this->getInternalValue('inquisition');
+		$account_id = $this->getInternalValue('account');
 
 		$sql = sprintf(
 			'select CMECredit.* from CMECredit
@@ -97,8 +98,10 @@ class CMEQuizResponse extends InquisitionResponse
 				inner join AccountCMEProgress on
 					AccountCMEProgress.id =
 					AccountCMEProgressCreditBinding.progress
-			where AccountCMEProgress.quiz = %s',
-			$this->db->quote($inquisition_id, 'integer')
+			where AccountCMEProgress.quiz = %s
+				and AccountCMEProgress.account = %s',
+			$this->db->quote($inquisition_id, 'integer'),
+			$this->db->quote($account_id, 'integer')
 		);
 
 		return SwatDB::query(


### PR DESCRIPTION
On the account details page for the RAP sites we do query nearly every
progress and response object so let's start by caching them right away.

PT Story: https://www.pivotaltracker.com/story/show/98337362