### PR TITLE
Fix fatal error on eval reports

### DIFF
--- a/sql/tables/AccountEarnedCMECredit.sql
+++ b/sql/tables/AccountEarnedCMECredit.sql
@@ -11,3 +11,9 @@ create index AccountEarnedCMECredit_account_index
 
 create index AccountEarnedCMECredit_credit_index
 	on AccountEarnedCMECredit(credit);
+
+create index AccountEarnedCMECredit_earned_date_index
+	on AccountEarnedCMECredit(earned_date);
+
+create index AccountEarnedCMECredit_earned_date_los_angeles_index
+	on AccountEarnedCMECredit(convertTZ(earned_date, 'America/Los_Angeles'));


### PR DESCRIPTION
This fixes the fatal error.

This makes sure we're querying the same rows in both `CMEReportUpdater` and `CMEEvaluationReportGenerator` https://github.com/silverorange/Cme/blob/master/CME/CMEEvaluationReportGenerator.php#L72-L96

The generation of the reports is still quite slow, but I'd suggest making a different PT story for that if it turns out to be a bottleneck in the future.

See also: https://github.com/silverorange/site/pull/144

PT story: https://www.pivotaltracker.com/story/show/98458890