### PR TITLE
Remove broken and unused method

### DIFF
--- a/CME/dataobjects/CMEAccount.php
+++ b/CME/dataobjects/CMEAccount.php
@@ -511,30 +511,6 @@ abstract class CMEAccount extends StoreAccount
 	}
 
 	// }}}
-	// {{{ protected function loadCMEFrontMatters()
-
-	protected function loadCMEFrontMatters()
-	{
-		require_once 'CME/dataobjects/CMEFrontMatterWrapper.php';
-
-		$wrapper = SwatDBClassMap::get('CMEFrontMatterWrapper');
-		$front_matters = new $wrapper();
-		$wrapper->setDatabase($this->db);
-
-		foreach ($this->cme_credits as $credit) {
-			$front_matter = $credit->front_matter;
-
-			// remove duplicate front matters from recordset
-			$wrapper_front_matter = $wrapper->getByIndex($front_matter->id);
-			if (!$wrapper_front_matter instanceof CMEFrontMatter) {
-				$wrapper->add($front_matter);
-			}
-		}
-
-		return $wrapper;
-	}
-
-	// }}}
 }
 
 ?>


### PR DESCRIPTION
There's no way this method is used anywhere - it's completely broken.

We try to set a database on a string instead of the dataobject:
```
$wrapper = SwatDBClassMap::get('CMEFrontMatterWrapper');
$wrapper->setDatabase($this->db);
```

There's also no `loadCMECredits()` method for `foreach ($this->cme_credits as $credit) {` to use.