### PR TITLE
Fix saving of Earned Credits

### DIFF
--- a/CME/pages/CMEFrontMatterAttestationServerPage.php
+++ b/CME/pages/CMEFrontMatterAttestationServerPage.php
@@ -163,8 +163,8 @@ class CMEFrontMatterAttestationServerPage extends SiteArticlePage
 		$wrapper = SwatDBClassMap::get('CMEAccountEarnedCMECreditWrapper');
 		$class_name = SwatDBClassMap::get('CMEAccountEarnedCMECredit');
 		$earned_credits = new $wrapper();
-		$earned_date = new SwatDate();
-		$earned_date->toUTC();
+		$now = new SwatDate();
+		$now->toUTC();
 		foreach ($front_matter->credits as $credit) {
 			if ($credit->isEarned($account)) {
 				// check for existing earned credit before saving


### PR DESCRIPTION
The variable name for the timestamp getting setup didn't match when it was used. This has been broken for a while, but is a less common code path so we haven't noticed it before.