### PR TITLE
Explicitly use mb_string functions where we deal with user-facing str…

### DIFF
--- a/CME/CME.php
+++ b/CME/CME.php
@@ -101,12 +101,7 @@ class CME
 
 	public static function setupGettext()
 	{
-		$path = '@DATA-DIR@/CME/locale';
-		if (substr($path, 0, 1) === '@') {
-			$path = __DIR__.'/../locale';
-		}
-
-		bindtextdomain(self::GETTEXT_DOMAIN, $path);
+		bindtextdomain(self::GETTEXT_DOMAIN, __DIR__.'/../locale');
 		bind_textdomain_codeset(self::GETTEXT_DOMAIN, 'UTF-8');
 	}
 

--- a/CME/CMEQuizReportGenerator.php
+++ b/CME/CMEQuizReportGenerator.php
@@ -343,7 +343,7 @@ class CMEQuizReportGenerator
 			switch ($address->country->id) {
 			case 'CA':
 				$postal_code = str_replace(array(' ', '-'), '', $postal_code);
-				$postal_code = strtoupper($postal_code);
+				$postal_code = mb_strtoupper($postal_code);
 				break;
 
 			case 'US':

--- a/CME/dataobjects/CMECredit.php
+++ b/CME/dataobjects/CMECredit.php
@@ -42,7 +42,7 @@ abstract class CMECredit extends SwatDBDataObject
 		$fractional_digits = mb_substr(mb_strrchr($hours, '.'), 1);
 		$decimal_places = (
 				mb_strlen($fractional_digits) === 2 &&
-				mb_substr($fractional_digits, -1) !== '0'
+				mb_substr($hours, -1) !== '0'
 			)
 			? 2
 			: 1;

--- a/CME/dataobjects/CMECredit.php
+++ b/CME/dataobjects/CMECredit.php
@@ -39,7 +39,7 @@ abstract class CMECredit extends SwatDBDataObject
 		// 4.5  -> 4.5
 		// 4.50 -> 4.5
 		// 4.25 -> 4.25
-		$fractional_digits = mb_substr(mb_strrchr($hours '.'), 1);
+		$fractional_digits = mb_substr(mb_strrchr($hours, '.'), 1);
 		$decimal_places = (
 				mb_strlen($fractional_digits) === 2 &&
 				mb_substr($fractional_digits, -1) !== '0'

--- a/CME/dataobjects/CMECredit.php
+++ b/CME/dataobjects/CMECredit.php
@@ -39,9 +39,10 @@ abstract class CMECredit extends SwatDBDataObject
 		// 4.5  -> 4.5
 		// 4.50 -> 4.5
 		// 4.25 -> 4.25
+		$fractional_digits = mb_substr(mb_strrchr($hours '.'), 1);
 		$decimal_places = (
-			strlen(substr(strrchr($hours, "."), 1)) === 2 &&
-			substr($hours, -1) !== '0'
+				mb_strlen($fractional_digits) === 2 &&
+				mb_substr($fractional_digits, -1) !== '0'
 			)
 			? 2
 			: 1;

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
 	],
 	"require": {
 		"php": ">=5.2.1",
+		"ext-mbstring": "*",
 		"dompdf/dompdf": "^0.7.0",
 		"silverorange/admin": "^3.2.0",
 		"silverorange/inquisition": "^1.0.0",


### PR DESCRIPTION
…ings

This allows us to turn off mb_string.func_overload.