### PR TITLE
Match method signature in Inquisition package

### DIFF
--- a/CME/admin/components/Option/Delete.php
+++ b/CME/admin/components/Option/Delete.php
@@ -19,7 +19,7 @@ class CMEOptionDelete extends InquisitionOptionDelete
 	// init phase
 	// {{{ public function setInquisition()
 
-	public function setInquisition(InquisitionInquisition $inquisition)
+	public function setInquisition(InquisitionInquisition $inquisition = null)
 	{
 		parent::setInquisition($inquisition);
 


### PR DESCRIPTION
Suppresses PHP 7 warning

https://hippoeducation.tpondemand.com/entity/3465-question-option-delete-method-signature-mismatch