### PR TITLE
Updates for ERcast

### DIFF
--- a/CME/admin/components/Evaluation/Details.php
+++ b/CME/admin/components/Evaluation/Details.php
@@ -20,7 +20,7 @@ class CMEEvaluationDetails extends InquisitionInquisitionDetails
 	{
 		return sprintf(
 			CME::_('%s Evaluation'),
-			$this->front_matter->provider->title
+			$this->front_matter->getProviderTitleList()
 		);
 	}
 

--- a/CME/admin/components/FrontMatter/edit.xml
+++ b/CME/admin/components/FrontMatter/edit.xml
@@ -33,7 +33,7 @@
 				<property name="note" translatable="yes">CME credit can only be earned for enabled front matter. Existing certificates for disabled front matter may still be printed.</property>
 				<widget class="SwatCheckbox" id="enabled" />
 			</widget>
-			<widget class="SwatFieldset">
+			<widget class="SwatFieldset" id="quiz_settings">
 				<property name="title" translatable="yes">CME Quiz Settings</property>
 				<widget class="SwatFormField">
 					<property name="title" translatable="yes">Passing Grade</property>

--- a/CME/admin/components/Question/include/CMEQuestionHelper.php
+++ b/CME/admin/components/Question/include/CMEQuestionHelper.php
@@ -213,7 +213,7 @@ class CMEQuestionHelper
 	{
 		return sprintf(
 			CME::_('%s Credit'),
-			$this->credit->front_matter->provider->title
+			$this->credit->front_matter->getProviderTitleList()
 		);
 	}
 
@@ -224,7 +224,7 @@ class CMEQuestionHelper
 	{
 		return sprintf(
 			CME::_('%s Evaluation'),
-			$this->front_matter->provider->title
+			$this->front_matter->getProviderTitleList()
 		);
 	}
 


### PR DESCRIPTION
Updates for https://github.com/HippoEducation/ercast/pull/7 

- Change `front_matter->provider->title` to `front_matter->getProviderTitleList()` on evaluation pages (this was made many-to-many awhile ago but these pages were previously unused so they weren't updated)
- Add ID to the quiz settings section of the FrontMatter edit page, so I can hide it in ERcast
