### PR TITLE
Update dompdf to 0.8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 	"require": {
 		"php": ">=5.2.1",
 		"ext-mbstring": "*",
-		"dompdf/dompdf": "^0.7.0",
+		"dompdf/dompdf": "^0.8.2",
 		"silverorange/admin": "^4.0.0",
 		"silverorange/inquisition": "^2.0.0",
 		"silverorange/site": "^6.0.0",


### PR DESCRIPTION
We are getting some errors from inside the dompdf library, which has had a few bug releases since our last update:

https://hippoeducation.tpondemand.com/entity/4676-errors-in-dompdf-library
https://github.com/dompdf/dompdf/releases

This particular bug (a non-numeric value encountered) is reported here and has been fixed in the latest version of dompdf:
https://github.com/dompdf/dompdf/issues/1272