### PR TITLE
Fix type hinting

### DIFF
--- a/CME/dataobjects/CMEAccount.php
+++ b/CME/dataobjects/CMEAccount.php
@@ -227,7 +227,7 @@ abstract class CMEAccount extends StoreAccount
 	// }}}
 	// {{{ public function getCMEProgress()
 
-	public function getCMEProgress(RapCredit $credit)
+	public function getCMEProgress(CMECredit $credit)
 	{
 		$this->checkDB();
 
@@ -330,7 +330,7 @@ abstract class CMEAccount extends StoreAccount
 	// }}}
 	// {{{ public function hasSameCMEProgress()
 
-	public function hasSameCMEProgress(RapCredit $credit1, RapCredit $credit2)
+	public function hasSameCMEProgress(CMECredit $credit1, CMECredit $credit2)
 	{
 		$progress1 = $this->getCMEProgress($credit1);
 		$progress2 = $this->getCMEProgress($credit2);


### PR DESCRIPTION
The CME package doesn't have Rap/Kos as a dependency so it shouldn't use Rap classes for type hinting. CMECredit is the base class for the RapCredit class so we can use this. 

Neither Kos or Rap have an override for these methods so we shouldn't get a mismatched signature error, but I tested out the CME flow on PC RAP just in case. 