### PR TITLE
Display credit expiry date in app timezone when editing

### DIFF
--- a/CME/admin/components/Credit/Edit.php
+++ b/CME/admin/components/Credit/Edit.php
@@ -82,6 +82,7 @@ abstract class CMECreditEdit extends InquisitionInquisitionEdit
 					)
 				);
 			}
+			$this->credit->expiry_date->convertTZ($this->app->default_time_zone);
 		} else {
 			$this->credit->is_free =
 				($this->app->initVar('credit_type') === 'free');
@@ -202,6 +203,7 @@ abstract class CMECreditEdit extends InquisitionInquisitionEdit
 
 		$this->credit->hours = $values['hours'];
 		$this->credit->expiry_date = $values['expiry_date'];
+		$this->credit->expiry_date->setTZ($this->app->default_time_zone)->toUTC();
 		$this->credit->quiz = $this->inquisition;
 		$this->credit->front_matter = $this->credit->front_matter->id;
 


### PR DESCRIPTION
Currently the edit page is setting the credit expiry time to be midnight UTC time of the chosen date. This causes a couple of issues:
- Other date entries (e.g. episode publish date) use midnight in the app time. Having this one be different means credits may expire before people expect. 
- The CME credit details page displays the expiry date in the app timezone, but the edit page displays the expiry date in UTC. E.g. if the app TZ is PST, setting the expiry date to Jan 1 2019 will display an expiry date of Dec 31 2018. 

To test:
- Check out this PR
- In PC RAP, run `gulp --symlinks=cme`
- Go to the credit details page and check the expiry date. 
- Hit "edit". The expiry shown on this page should match the previous page.  
- Change the date and hit "submit". The expiry date should still match on the details page. 