### PR TITLE
Make quiz optional by checking if the quiz has questions

### DIFF
--- a/CME/CMEQuizReportGenerator.php
+++ b/CME/CMEQuizReportGenerator.php
@@ -232,7 +232,7 @@ class CMEQuizReportGenerator
 		return array(
 			'Last Name',
 			'First Name',
-			'Type',
+			'Suffix',
 			'Email',
 			'Address',
 			'City',
@@ -365,19 +365,9 @@ class CMEQuizReportGenerator
 
 	protected function formatSuffix(SiteAccount $account)
 	{
-		switch ($account->getInternalValue('profession')) {
-		case 1 :
-		case 2 :
-			return 'MD';
-		case 3 :
-			return 'NP';
-		case 4 :
-			return 'PA';
-		case 5 :
-			return 'Nurse';
-		default :
-			return 'Other';
-		}
+		return ($account->hasPublicProperty('suffix'))
+			? $account->suffix
+			: '';
 	}
 
 	// }}}

--- a/CME/CMEQuizReportGenerator.php
+++ b/CME/CMEQuizReportGenerator.php
@@ -232,7 +232,7 @@ class CMEQuizReportGenerator
 		return array(
 			'Last Name',
 			'First Name',
-			'Suffix',
+			'Type',
 			'Email',
 			'Address',
 			'City',
@@ -365,9 +365,19 @@ class CMEQuizReportGenerator
 
 	protected function formatSuffix(SiteAccount $account)
 	{
-		return ($account->hasPublicProperty('suffix'))
-			? $account->suffix
-			: '';
+		switch ($account->getInternalValue('profession')) {
+		case 1 :
+		case 2 :
+			return 'MD';
+		case 3 :
+			return 'NP';
+		case 4 :
+			return 'PA';
+		case 5 :
+			return 'Nurse';
+		default :
+			return 'Other';
+		}
 	}
 
 	// }}}

--- a/CME/dataobjects/CMECredit.php
+++ b/CME/dataobjects/CMECredit.php
@@ -64,6 +64,16 @@ abstract class CMECredit extends SwatDBDataObject
 	}
 
 	// }}}
+	// {{{ public function hasQuiz()
+
+	public function hasQuiz()
+	{
+		return $this->getInternalValue('quiz') !== null &&
+			$this->quiz instanceof CMEQuiz &&
+			count($this->quiz->question_bindings) > 0;
+	}
+
+	// }}}
 	// {{{ public function isEarned()
 
 	public function isEarned(CMEAccount $account)
@@ -72,7 +82,7 @@ abstract class CMECredit extends SwatDBDataObject
 		return (
 				$account->hasAttested($this->front_matter)
 			) && (
-				!$this->quiz instanceof CMEQuiz ||
+				!$this->hasQuiz() ||
 				$account->isQuizPassed($this)
 			) && (
 				!$this->front_matter->evaluation instanceof CMEEvaluation ||


### PR DESCRIPTION
The DB has quiz `not null` and the admin is built in a way that ties adding credit hours to adding a quiz. To get around this and keep things as simple as possible, we just need to also check if the quiz has any questions before requiring it.

Interestingly, the CMEEvaluationPage currently checks if the quiz doesn't exist before saving earned-credits. All we have to do is change that to check if the quiz doesn't have questions and then it correctly saves the status.