### PR TITLE
Update dompdf for PHP 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 	"require": {
 		"php": ">=5.2.1",
 		"ext-mbstring": "*",
-		"dompdf/dompdf": "^0.8.2",
+		"dompdf/dompdf": "^2.0.0",
 		"silverorange/admin": "^5.4.0",
 		"silverorange/inquisition": "^4.1.0",
 		"silverorange/site": "^9.0.0 || ^10.1.1",


### PR DESCRIPTION
There are no listed breaking changes on the dompdf releases. Our use of the API is pretty simplistic, we just use the constructor, loadHtml, render, and output, all of which is located in the `CMEEvaluationReportGenerator` https://github.com/silverorange/Cme/blob/master/CME/CMEEvaluationReportGenerator.php#L235 . We should be safe to upgrade to 2.0.0 without any code changes 


https://github.com/dompdf/dompdf/releases
