### PR TITLE
Allow versions 11-13 of Site in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
 		"dompdf/dompdf": "^2.0.0",
 		"silverorange/admin": "^5.4.0",
 		"silverorange/inquisition": "^4.1.0",
-		"silverorange/site": "^9.0.0 || ^10.1.1",
+		"silverorange/site": "^9.0.0 || ^10.1.1 || ^11.0.0 || ^12.0.0 || ^13.0.0",
 		"silverorange/swat": "^5.0.0 || ^6.0.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
Version 11 uses the new version of Sentry and deprecates
getSentryClient, which cme does not use.

Version 12 deprecates akismet, which cme does not use at all

Version 13 deprecates net notifier. Searching "notifier",
"Net_Notifier", and "sendNotification" yielded no results, so we're safe
here too