### PR TITLE
Allow site 14 and admin 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
 		"php": ">=5.2.1",
 		"ext-mbstring": "*",
 		"dompdf/dompdf": "^2.0.0",
-		"silverorange/admin": "^5.4.0",
+		"silverorange/admin": "^5.4.0 || ^6.0.0",
 		"silverorange/inquisition": "^4.1.0",
-		"silverorange/site": "^9.0.0 || ^10.1.1 || ^11.0.0 || ^12.0.0 || ^13.0.0",
+		"silverorange/site": "^9.0.0 || ^10.1.1 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0",
 		"silverorange/swat": "^5.0.0 || ^6.0.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
Site 14 and admin 6 are both tasked with removing nategosearch. Since
cme doesn't use nategosearch or make any references to
the addToSearchQueue method, we are good to allow either version.