### PR TITLE
reverse the order of the report rows

### DIFF
--- a/CME/admin/components/EvaluationReport/Index.php
+++ b/CME/admin/components/EvaluationReport/Index.php
@@ -194,6 +194,7 @@ class CMEEvaluationReportIndex extends AdminIndex
 						$ds->{'is_'.$shortname.'_sensitive'} = $sensitive;
 					}
 
+					// reverse the order so we can display newest to oldest
 					array_unshift($quarters, $ds);
 				}
 
@@ -205,6 +206,7 @@ class CMEEvaluationReportIndex extends AdminIndex
 			$year++;
 		}
 
+		// display the quarters in reversed order
 		$store = new SwatTableStore();
 		foreach($quarters as $ds) {
 			$store->add($ds);

--- a/CME/admin/components/EvaluationReport/Index.php
+++ b/CME/admin/components/EvaluationReport/Index.php
@@ -163,7 +163,7 @@ class CMEEvaluationReportIndex extends AdminIndex
 		$display_end_date = clone $end_date;
 		$display_end_date->subtractMonths(1);
 
-		$store = new SwatTableStore();
+		$quarters = [];
 
 		while ($end_date->before($now)) {
 			for ($i = 1; $i <= 4; $i++) {
@@ -194,7 +194,7 @@ class CMEEvaluationReportIndex extends AdminIndex
 						$ds->{'is_'.$shortname.'_sensitive'} = $sensitive;
 					}
 
-					$store->add($ds);
+					array_unshift($quarters, $ds);
 				}
 
 				$start_date->addMonths(3);
@@ -203,6 +203,11 @@ class CMEEvaluationReportIndex extends AdminIndex
 			}
 
 			$year++;
+		}
+
+		$store = new SwatTableStore();
+		foreach($quarters as $ds) {
+			$store->add($ds);
 		}
 
 		return $store;

--- a/CME/admin/components/QuizReport/Index.php
+++ b/CME/admin/components/QuizReport/Index.php
@@ -162,7 +162,7 @@ class CMEQuizReportIndex extends AdminIndex
 		$display_end_date = clone $end_date;
 		$display_end_date->subtractMonths(1);
 
-		$store = new SwatTableStore();
+		$quarters = [];
 
 		while ($end_date->before($now)) {
 			for ($i = 1; $i <= 4; $i++) {
@@ -194,7 +194,7 @@ class CMEQuizReportIndex extends AdminIndex
 						$ds->{'is_'.$shortname.'_sensitive'} = $sensitive;
 					}
 
-					$store->add($ds);
+					array_unshift($quarters, $ds);
 				}
 
 				$start_date->addMonths(3);
@@ -205,6 +205,10 @@ class CMEQuizReportIndex extends AdminIndex
 			$year++;
 		}
 
+		$store = new SwatTableStore();
+		foreach($quarters as $ds) {
+			$store->add($ds);
+		}
 		return $store;
 	}
 

--- a/CME/admin/components/QuizReport/Index.php
+++ b/CME/admin/components/QuizReport/Index.php
@@ -194,6 +194,7 @@ class CMEQuizReportIndex extends AdminIndex
 						$ds->{'is_'.$shortname.'_sensitive'} = $sensitive;
 					}
 
+					// reverse the order so we can display newest to oldest
 					array_unshift($quarters, $ds);
 				}
 
@@ -205,6 +206,7 @@ class CMEQuizReportIndex extends AdminIndex
 			$year++;
 		}
 
+		// display the quarters in reversed order
 		$store = new SwatTableStore();
 		foreach($quarters as $ds) {
 			$store->add($ds);


### PR DESCRIPTION
Reverses the order of the Quiz and Evaluation report pages.

### To Test
1. check out the PR in your working dir for the CME pacakge: `/so/packages/cme/work-{username}`
2. next, go to `cd /so/sites/emrap/work-{username}`
3. run `yarn start --symlinks=cme` to test the changes in the CME package
4. in a browser, go to the admin and login: `berna.silverorange.com/emrap/work-{username}/www/admin/`
5. in the admin, go to the "Reports > Quizzes" and "Reports > Evaluations" and make sure that the dates are listed reverse chronologically (newest reports first)
6. to see before/after, just stop yarn, and remove the `--symlinks` flag (before), and then re-add it (after).