### PR TITLE
Remove redundant types and add specific array-types

### DIFF
--- a/CME/dataobjects/CMEAccount.php
+++ b/CME/dataobjects/CMEAccount.php
@@ -6,27 +6,16 @@
  * @copyright 2011-2016 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
  *
- * @property ?array                           $cme_progress_by_credit
- * @property ?array                           $response_by_cme_quiz
- * @property ?array                           $response_by_cme_eval
- * @property CMECreditWrapper                 $attested_cme_credits
- * @property CMEAccountEarnedCMECreditWrapper $earned_cme_credits
+ * @property ?array<int, CMEAccountCMEProgress> $cme_progress_by_credit
+ * @property ?array<int, CMEQuiz>               $response_by_cme_quiz
+ * @property ?array<int, CMEEvaluation>         $response_by_cme_eval
+ * @property CMECreditWrapper                   $attested_cme_credits
+ * @property CMEAccountEarnedCMECreditWrapper   $earned_cme_credits
  */
 abstract class CMEAccount extends StoreAccount
 {
-    /**
-     * @var array
-     */
     protected $cme_progress_by_credit;
-
-    /**
-     * @var array
-     */
     protected $response_by_cme_quiz;
-
-    /**
-     * @var array
-     */
     protected $response_by_cme_eval;
 
     abstract public function hasCMEAccess();

--- a/CME/dataobjects/CMEAccount.php
+++ b/CME/dataobjects/CMEAccount.php
@@ -6,17 +6,25 @@
  * @copyright 2011-2016 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
  *
- * @property ?array<int, CMEAccountCMEProgress> $cme_progress_by_credit
- * @property ?array<int, CMEQuiz>               $response_by_cme_quiz
- * @property ?array<int, CMEEvaluation>         $response_by_cme_eval
- * @property CMECreditWrapper                   $attested_cme_credits
- * @property CMEAccountEarnedCMECreditWrapper   $earned_cme_credits
+ * @property CMECreditWrapper                 $attested_cme_credits
+ * @property CMEAccountEarnedCMECreditWrapper $earned_cme_credits
  */
 abstract class CMEAccount extends StoreAccount
 {
-    protected $cme_progress_by_credit;
-    protected $response_by_cme_quiz;
-    protected $response_by_cme_eval;
+    /**
+     * @var ?array<int, CMEAccountCMEProgress>
+     */
+    protected ?array $cme_progress_by_credit;
+
+    /**
+     * @var ?array<int, CMEQuiz>
+     */
+    protected ?array $response_by_cme_quiz;
+
+    /**
+     * @var ?array<int, CMEEvaluation>
+     */
+    protected ?array $response_by_cme_eval;
 
     abstract public function hasCMEAccess();
 

--- a/CME/dataobjects/CMEAccountCMEProgress.php
+++ b/CME/dataobjects/CMEAccountCMEProgress.php
@@ -6,13 +6,15 @@
  * @copyright 2015-2016 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
  *
- * @property int            $id
  * @property CMEAccount     $account
  * @property ?CMEQuiz       $quiz
  * @property ?CMEEvaluation $evaluation
  */
 class CMEAccountCMEProgress extends SwatDBDataObject
 {
+    /**
+     * @var int
+     */
     public $id;
 
     protected function init()

--- a/CME/dataobjects/CMEAccountCMEProgress.php
+++ b/CME/dataobjects/CMEAccountCMEProgress.php
@@ -13,9 +13,6 @@
  */
 class CMEAccountCMEProgress extends SwatDBDataObject
 {
-    /**
-     * @var int
-     */
     public $id;
 
     protected function init()

--- a/CME/dataobjects/CMEAccountEarnedCMECredit.php
+++ b/CME/dataobjects/CMEAccountEarnedCMECredit.php
@@ -13,14 +13,7 @@
  */
 class CMEAccountEarnedCMECredit extends SwatDBDataObject
 {
-    /**
-     * @var int
-     */
     public $id;
-
-    /**
-     * @var SwatDate
-     */
     public $earned_date;
 
     protected function init()

--- a/CME/dataobjects/CMEAccountEarnedCMECredit.php
+++ b/CME/dataobjects/CMEAccountEarnedCMECredit.php
@@ -6,14 +6,19 @@
  * @copyright 2011-2016 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
  *
- * @property int        $id
- * @property ?SwatDate  $earned_date
  * @property CMEAccount $account
  * @property CMECredit  $credit
  */
 class CMEAccountEarnedCMECredit extends SwatDBDataObject
 {
+    /**
+     * @var int
+     */
     public $id;
+
+    /**
+     * @var SwatDate
+     */
     public $earned_date;
 
     protected function init()

--- a/CME/dataobjects/CMECredit.php
+++ b/CME/dataobjects/CMECredit.php
@@ -13,24 +13,9 @@
  */
 abstract class CMECredit extends SwatDBDataObject
 {
-    /**
-     * @var int
-     */
     public $id;
-
-    /**
-     * @var float
-     */
     public $hours;
-
-    /**
-     * @var bool
-     */
     public $is_free;
-
-    /**
-     * @var SwatDate
-     */
     public $expiry_date;
 
     public static function formatCreditHours($hours)

--- a/CME/dataobjects/CMECredit.php
+++ b/CME/dataobjects/CMECredit.php
@@ -4,18 +4,29 @@
  * @copyright 2013-2016 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
  *
- * @property int            $id
- * @property ?float         $hours
- * @property ?bool          $is_free
- * @property ?SwatDate      $expiry_date
  * @property CMEFrontMatter $front_matter
  * @property ?CMEQuiz       $quiz
  */
 abstract class CMECredit extends SwatDBDataObject
 {
+    /**
+     * @var int
+     */
     public $id;
+
+    /**
+     * @var float
+     */
     public $hours;
+
+    /**
+     * @var bool
+     */
     public $is_free;
+
+    /**
+     * @var SwatDate
+     */
     public $expiry_date;
 
     public static function formatCreditHours($hours)

--- a/CME/dataobjects/CMEEvaluationReport.php
+++ b/CME/dataobjects/CMEEvaluationReport.php
@@ -4,23 +4,33 @@
  * @copyright 2011-2016 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
  *
- * @property int         $id
- * @property ?string     $filename
- * @property ?SwatDate   $quarter
- * @property ?SwatDate   $createdate
- * @property ?string     $file_base
  * @property CMEProvider $provider
  */
 class CMEEvaluationReport extends SwatDBDataObject
 {
+    /**
+     * @var int
+     */
     public $id;
+
+    /**
+     * @var string
+     */
     public $filename;
+
+    /**
+     * @var SwatDate
+     */
     public $quarter;
+
+    /**
+     * @var SwatDate
+     */
     public $createdate;
 
-    protected $file_base;
+    protected string $file_base = '';
 
-    public function setFileBase($file_base)
+    public function setFileBase(string $file_base): void
     {
         $this->file_base = $file_base;
     }

--- a/CME/dataobjects/CMEEvaluationReport.php
+++ b/CME/dataobjects/CMEEvaluationReport.php
@@ -13,29 +13,11 @@
  */
 class CMEEvaluationReport extends SwatDBDataObject
 {
-    /**
-     * @var int
-     */
     public $id;
-
-    /**
-     * @var string
-     */
     public $filename;
-
-    /**
-     * @var SwatDate
-     */
     public $quarter;
-
-    /**
-     * @var SwatDate
-     */
     public $createdate;
 
-    /**
-     * @var string
-     */
     protected $file_base;
 
     public function setFileBase($file_base)

--- a/CME/dataobjects/CMEFrontMatter.php
+++ b/CME/dataobjects/CMEFrontMatter.php
@@ -23,69 +23,18 @@
  */
 abstract class CMEFrontMatter extends SwatDBDataObject
 {
-    /**
-     * @var int
-     */
     public $id;
-
-    /**
-     * @var string
-     */
     public $objectives;
-
-    /**
-     * @var string
-     */
     public $planning_committee_no_disclosures;
-
-    /**
-     * @var string
-     */
     public $planning_committee_with_disclosures;
-
-    /**
-     * @var string
-     */
     public $support_staff_no_disclosures;
-
-    /**
-     * @var string
-     */
     public $support_staff_with_disclosures;
-
-    /**
-     * @var SwatDate
-     */
     public $release_date;
-
-    /**
-     * @var SwatDate
-     */
     public $review_date;
-
-    /**
-     * @var bool
-     */
     public $enabled;
-
-    /**
-     * @var int
-     */
     public $passing_grade;
-
-    /**
-     * @var string
-     */
     public $email_content_pass;
-
-    /**
-     * @var string
-     */
     public $email_content_fail;
-
-    /**
-     * @var bool
-     */
     public $resettable;
 
     public function getProviderTitleList()

--- a/CME/dataobjects/CMEFrontMatter.php
+++ b/CME/dataobjects/CMEFrontMatter.php
@@ -4,37 +4,75 @@
  * @copyright 2013-2016 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
  *
- * @property int                $id
- * @property ?string            $objectives
- * @property ?string            $planning_committee_no_disclosures
- * @property ?string            $planning_committee_with_disclosures
- * @property ?string            $support_staff_no_disclosures
- * @property ?string            $support_staff_with_disclosures
- * @property ?SwatDate          $review_date
- * @property ?SwatDate          $release_date
- * @property ?bool              $enabled
- * @property ?int               $passing_grade
- * @property ?string            $email_content_pass
- * @property ?string            $email_content_fail
- * @property ?bool              $resettable
  * @property ?CMEEvaluation     $evaluation
  * @property CMECreditWrapper   $credits
  * @property CMEProviderWrapper $providers
  */
 abstract class CMEFrontMatter extends SwatDBDataObject
 {
+    /**
+     * @var int
+     */
     public $id;
+
+    /**
+     * @var ?string
+     */
     public $objectives;
+
+    /**
+     * @var ?string
+     */
     public $planning_committee_no_disclosures;
+
+    /**
+     * @var ?string
+     */
     public $planning_committee_with_disclosures;
+
+    /**
+     * @var ?string
+     */
     public $support_staff_no_disclosures;
+
+    /**
+     * @var ?string
+     */
     public $support_staff_with_disclosures;
+
+    /**
+     * @var ?SwatDate
+     */
     public $release_date;
+
+    /**
+     * @var ?SwatDate
+     */
     public $review_date;
+
+    /**
+     * @var bool
+     */
     public $enabled;
+
+    /**
+     * @var ?float
+     */
     public $passing_grade;
+
+    /**
+     * @var ?string
+     */
     public $email_content_pass;
+
+    /**
+     * @var ?string
+     */
     public $email_content_fail;
+
+    /**
+     * @var bool
+     */
     public $resettable;
 
     public function getProviderTitleList()

--- a/CME/dataobjects/CMEProvider.php
+++ b/CME/dataobjects/CMEProvider.php
@@ -3,21 +3,37 @@
 /**
  * @copyright 2013-2016 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
- *
- * @property int     $id
- * @property ?string $shortname
- * @property ?string $title
- * @property ?string $credit_title
- * @property ?string $credit_title_plural
- * @property ?int    $displayorder
  */
 class CMEProvider extends SwatDBDataObject
 {
+    /**
+     * @var int
+     */
     public $id;
+
+    /**
+     * @var string
+     */
     public $shortname;
+
+    /**
+     * @var string
+     */
     public $title;
+
+    /**
+     * @var string
+     */
     public $credit_title;
+
+    /**
+     * @var string
+     */
     public $credit_title_plural;
+
+    /**
+     * @var int
+     */
     public $displayorder;
 
     public function loadByShortname($shortname)

--- a/CME/dataobjects/CMEProvider.php
+++ b/CME/dataobjects/CMEProvider.php
@@ -13,34 +13,11 @@
  */
 class CMEProvider extends SwatDBDataObject
 {
-    /**
-     * @var int
-     */
     public $id;
-
-    /**
-     * @var string
-     */
     public $shortname;
-
-    /**
-     * @var string
-     */
     public $title;
-
-    /**
-     * @var string
-     */
     public $credit_title;
-
-    /**
-     * @var string
-     */
     public $credit_title_plural;
-
-    /**
-     * @var int
-     */
     public $displayorder;
 
     public function loadByShortname($shortname)

--- a/CME/dataobjects/CMEQuizReport.php
+++ b/CME/dataobjects/CMEQuizReport.php
@@ -4,23 +4,33 @@
  * @copyright 2011-2016 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
  *
- * @property int         $id
- * @property ?string     $filename
- * @property ?SwatDate   $quarter
- * @property ?SwatDate   $createdate
- * @property ?string     $file_base
  * @property CMEProvider $provider
  */
 class CMEQuizReport extends SwatDBDataObject
 {
+    /**
+     * @var int
+     */
     public $id;
+
+    /**
+     * @var string
+     */
     public $filename;
+
+    /**
+     * @var SwatDate
+     */
     public $quarter;
+
+    /**
+     * @var SwatDate
+     */
     public $createdate;
 
-    protected $file_base;
+    protected string $file_base = '';
 
-    public function setFileBase($file_base)
+    public function setFileBase(string $file_base): void
     {
         $this->file_base = $file_base;
     }

--- a/CME/dataobjects/CMEQuizReport.php
+++ b/CME/dataobjects/CMEQuizReport.php
@@ -13,29 +13,11 @@
  */
 class CMEQuizReport extends SwatDBDataObject
 {
-    /**
-     * @var int
-     */
     public $id;
-
-    /**
-     * @var string
-     */
     public $filename;
-
-    /**
-     * @var SwatDate
-     */
     public $quarter;
-
-    /**
-     * @var SwatDate
-     */
     public $createdate;
 
-    /**
-     * @var string
-     */
     protected $file_base;
 
     public function setFileBase($file_base)

--- a/CME/dataobjects/CMEQuizResponse.php
+++ b/CME/dataobjects/CMEQuizResponse.php
@@ -12,9 +12,6 @@
  */
 class CMEQuizResponse extends InquisitionResponse
 {
-    /**
-     * @var SwatDate
-     */
     public $reset_date;
 
     public function getCorrectCount()

--- a/CME/dataobjects/CMEQuizResponse.php
+++ b/CME/dataobjects/CMEQuizResponse.php
@@ -6,12 +6,14 @@
  * @copyright 2011-2016 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
  *
- * @property ?SwatDate        $reset_date
  * @property CMEAccount       $account
  * @property CMECreditWrapper $credits
  */
 class CMEQuizResponse extends InquisitionResponse
 {
+    /**
+     * @var ?SwatDate
+     */
     public $reset_date;
 
     public function getCorrectCount()


### PR DESCRIPTION
# Description

Removes `@property` docblocks in favour of `@var` docs. Adds specific array types for local cache arrays.

See previous https://github.com/silverorange/Cme/pull/120

# Testing Instructions (optional)

Add step-by-step instructions for testing the PR, if necessary.

1. Make sure Jenkins CI passes
2. Make sure type inference in IDE still works.

# Developer Checklist

Before requesting review for this PR, make sure the following tasks are
complete:

- [ ] I added a link to the relevant Shortcut story, if applicable
- [x] I added testing instructions, if any
- [ ] I made sure existing CI checks pass
- [ ] I checked that all requirements of the ticket are fulfilled

# Reviewer Checklist

Before merging this PR, make sure the following tasks are complete:

- [ ] I made sure there are no active labels that block merge
- [ ] I followed the testing instructions
- [ ] I made sure the CI checks pass
- [ ] I reviewed the file changes on GitHub
- [ ] I checked that all requirements of the ticket (if any) are fulfilled
