### PR TITLE
Set up tailscale for CI pipeline

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -10,6 +10,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Setup Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.SILVERORANGE_TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.SILVERORANGE_TAILSCALE_OAUTH_SECRET }}
+          tags: tag:silverorange-gh-actions
+          version: latest
+
       - name: Check out repository code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
# Description

Sets up Tailscale at beginning of GitHub Actions CI pipeline, so that we can connect to the private composer repo.